### PR TITLE
minor improvements: ip6 support, TXT precedes SPF, small bugfixes

### DIFF
--- a/hydrate_spf/hydrate_spf.py
+++ b/hydrate_spf/hydrate_spf.py
@@ -49,15 +49,10 @@ def hydrate_mechanism(mechanism, domain=None):
     if "+" in mechanism:
         mechanism = mechanism.strip('+')
 
-    if mechanism == 'ip4':
+    if mechanism == 'ip4' or mechanism == 'ip6':
         hydration = '%s:%s' % (mechanism, value)
         if netmask:
             hydration += ('/%s' % netmask)
-        return hydration
-    if mechanism == 'ip6':
-        hydration = '%s:%s' % (mechanism, value)
-        if netmask:
-            hydration += ('/%s' % netmask6)
         return hydration
     if mechanism == 'a':
         records = []


### PR DESCRIPTION
 - added code to strip "+" from mechanisms if it is added explicitly (like `+ip4`); maybe should do something with `-`, too, but I did not encountered this yet, if I will, I will fix
 - added `ip6` handling
 - checking TXT first and if it is missing then fall back to SPF (as SPF is deprecated and it's handling is broken; in case of for example `email.chargebee.com` it also does find its `CNAME` and things go south; but I did not fix this as I not care for SPF-type records)
 - added check for `mechanisms` to determine if it is really an SPF entry (contains `spfPrefix`), returning empty string if not (as it is still better than breaking, and in my application I filter out empty results so it fits my needs)